### PR TITLE
string1 should not generate empty strings

### DIFF
--- a/Test/QuickCheck/Unicode.hs
+++ b/Test/QuickCheck/Unicode.hs
@@ -88,11 +88,11 @@ list gen = listN 0 gen
 list1 :: Gen a -> Gen [a]
 list1 gen = listN 1 gen
 
--- | Generate a list of at least /n/ values.
+-- | Generate a list of at least /m/ values.
 listN :: Int -> Gen a -> Gen [a]
 listN m gen =
   sized $ \n ->
-    do k <- choose (m,n)
+    do k <- choose (m,max m n)
        vectorOf k gen
 
 -- | Shrink a Unicode code point.

--- a/Test/QuickCheck/Unicode.hs
+++ b/Test/QuickCheck/Unicode.hs
@@ -78,7 +78,7 @@ string = list char
 
 -- | Generate a non-empty list of Unicode code points.
 string1 :: Gen String
-string1 = list char
+string1 = list1 char
 
 -- | Generate a list of values.
 list :: Gen a -> Gen [a]


### PR DESCRIPTION
Before this fix it did:
``` Haskell
λ> sample string1
""
"\EM"
"b\917802Z7"
```